### PR TITLE
Updated web server behavior

### DIFF
--- a/Firmware/arduino/2Wireless/2Wireless.ino
+++ b/Firmware/arduino/2Wireless/2Wireless.ino
@@ -136,6 +136,7 @@ int keyIndex = 0;                // your network key Index number (needed only f
 
 int status = WL_IDLE_STATUS;
 WiFiServer server(80);
+WiFiClient client;
 
 void setup() {
   //Set this stuff up first so we are ready for firmware requests from modules.
@@ -228,7 +229,6 @@ void setup() {
 
 
 void loop() {
-  WiFiClient client;
   // compare the previous status to the current status
   if (status != WiFi.status()) {
     // it has changed update the variable

--- a/Firmware/arduino/2Wireless/2Wireless.ino
+++ b/Firmware/arduino/2Wireless/2Wireless.ino
@@ -243,7 +243,7 @@ void loop() {
     } else {
       // a device has disconnected from the AP, and we are back in listening mode
       DEBUG_PRINTLN("Device disconnected from AP");
-      client.stop();
+      if (client) client.stop();
     }
   }
   


### PR DESCRIPTION
# Use case
I find that with an iPad dedicated to being the web interface to the WPM that over intervals that would include power saving and other non-WPM device behavior, reconnecting rarely works. The Wifi network can always be re-established but connections to port 80 seemed to time out.

The fixes in this PR alter the timing of when the web server starts and improves client cleanup.

# Change Summary
There are a few changes, minor ones are listed first:
- Updated a few debugging points that weren't properly categorized
- Removed a debug line that ends up being mostly noise
- Moved `server.begin()` into the loop
- Made a few small modifications to the circumstances when a/the web server is started
- Improved client cleanup